### PR TITLE
chore: adjust extension version

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "kind",
   "displayName": "Kind",
   "description": "Integration for Kind: run local Kubernetes clusters using container “nodes”",
-  "version": "0.0.1",
+  "version": "0.1.0-next",
   "icon": "icon.png",
   "publisher": "podman-desktop",
   "license": "Apache-2.0",


### PR DESCRIPTION
Adjusting the extension version from 0.1.0 to 0.0.1, since in the release of 0.1.0, having already the 0.1.0 will lead to failure in the release workflow with `nothing to commit, working tree clean` in the `tag` step