### PR TITLE
chore: address fixes for ESlint major version 10

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -66,10 +66,10 @@ export default [
   ),
   {
     plugins: {
-      // compliant v9 plug-ins
+      // compliant v10 plug-ins
       unicorn,
-      'file-progress': fileProgress,
-      // non-compliant v9 plug-ins
+      // non-compliant v10 plug-ins
+      'file-progress': fixupPluginRules(fileProgress),
       etc: fixupPluginRules(etc),
       import: fixupPluginRules(importPlugin),
       'no-null': fixupPluginRules(noNull),

--- a/src/create-cluster.spec.ts
+++ b/src/create-cluster.spec.ts
@@ -696,9 +696,7 @@ test('waitForCoreDNSReady should handle errors and cleanup properly', async () =
     warn: vi.fn(),
   };
   const mockKubeConfig = new KubeConfig();
-  await expect(waitForCoreDNSReady(mockKubeConfig, logger)).rejects.toThrow(
-    'Cluster not ready',
-  );
+  await expect(waitForCoreDNSReady(mockKubeConfig, logger)).rejects.toThrow('Cluster not ready');
 
   expect(KindClusterWatcher.prototype.dispose).toHaveBeenCalled();
 });

--- a/src/create-cluster.spec.ts
+++ b/src/create-cluster.spec.ts
@@ -87,7 +87,7 @@ test('expect error is cli returns non zero exit code', async () => {
     await createCluster({}, '', telemetryLoggerMock);
   } catch (err) {
     expect(err).to.be.a('Error');
-    expect((err as Error).message).equal('Failed to create kind cluster. error');
+    expect((err as Error).message).equal('Failed to create kind cluster');
     expect(telemetryLogUsageMock).toBeCalledWith('createCluster', expect.objectContaining({ error: error }));
     expect(telemetryLogErrorMock).not.toBeCalled();
   }
@@ -370,7 +370,7 @@ test('expect error if Kubernetes reports error', async () => {
   } catch (err) {
     expect(extensionApi.kubernetes.createResources).toBeCalled();
     expect(err).to.be.a('Error');
-    expect((err as Error).message).equal('Failed to create kind cluster. Kubernetes error');
+    expect((err as Error).message).equal('Failed to create kind cluster');
     expect(telemetryLogErrorMock).not.toBeCalled();
     expect(telemetryLogUsageMock).toBeCalledWith('createCluster', expect.objectContaining(error));
   }
@@ -697,7 +697,7 @@ test('waitForCoreDNSReady should handle errors and cleanup properly', async () =
   };
   const mockKubeConfig = new KubeConfig();
   await expect(waitForCoreDNSReady(mockKubeConfig, logger)).rejects.toThrow(
-    'Cluster not ready: Error: Nodes not ready',
+    'Cluster not ready',
   );
 
   expect(KindClusterWatcher.prototype.dispose).toHaveBeenCalled();

--- a/src/create-cluster.ts
+++ b/src/create-cluster.ts
@@ -124,7 +124,7 @@ export async function waitForCoreDNSReady(kubeConfig: KubeConfig, logger?: exten
     logger?.log('CoreDNS ready');
     logger?.log('All cluster components ready');
   } catch (error) {
-    throw new Error(`Cluster not ready: ${String(error)}`);
+    throw new Error('Cluster not ready', { cause: error });
   } finally {
     watcher.dispose();
   }
@@ -353,15 +353,7 @@ export async function createCluster(
     }
   } catch (error) {
     telemetryOptions.error = error;
-    let errorMessage = '';
-
-    if (error && typeof error === 'object' && 'message' in error) {
-      errorMessage = String(error.message);
-    } else if (typeof error === 'string') {
-      errorMessage = error;
-    }
-
-    throw new Error(`Failed to create kind cluster. ${errorMessage}`);
+    throw new Error('Failed to create kind cluster.', { cause: error });
   } finally {
     const endTime = performance.now();
     telemetryOptions.duration = endTime - startTime;

--- a/src/create-cluster.ts
+++ b/src/create-cluster.ts
@@ -353,7 +353,7 @@ export async function createCluster(
     }
   } catch (error) {
     telemetryOptions.error = error;
-    throw new Error('Failed to create kind cluster.', { cause: error });
+    throw new Error('Failed to create kind cluster', { cause: error });
   } finally {
     const endTime = performance.now();
     telemetryOptions.duration = endTime - startTime;

--- a/src/image-handler.ts
+++ b/src/image-handler.ts
@@ -97,7 +97,7 @@ export class ImageHandler {
         );
 
         // Throw the errors to the console aswell
-        throw new Error(`Unable to push image to Kind cluster: ${err}`);
+        throw new Error('Unable to push image to Kind cluster:', { cause: err });
       } finally {
         // Remove the temporary file if one was created
         if (filename !== undefined) {

--- a/src/image-handler.ts
+++ b/src/image-handler.ts
@@ -97,7 +97,7 @@ export class ImageHandler {
         );
 
         // Throw the errors to the console aswell
-        throw new Error('Unable to push image to Kind cluster:', { cause: err });
+        throw new Error('Unable to push image to Kind cluster', { cause: err });
       } finally {
         // Remove the temporary file if one was created
         if (filename !== undefined) {

--- a/src/kind-installer.spec.ts
+++ b/src/kind-installer.spec.ts
@@ -75,7 +75,9 @@ test('error: expect installBinaryToSystem to fail with a non existing binary', a
 
   vi.spyOn(extensionApi.process, 'exec').mockRejectedValue(new Error('test error'));
 
-  await expect(() => util.installBinaryToSystem('test', 'tmpBinary')).rejects.toThrowError('Error making binary executable');
+  await expect(() => util.installBinaryToSystem('test', 'tmpBinary')).rejects.toThrowError(
+    'Error making binary executable',
+  );
 });
 
 describe('grabLatestsReleasesMetadata', () => {

--- a/src/kind-installer.spec.ts
+++ b/src/kind-installer.spec.ts
@@ -75,7 +75,7 @@ test('error: expect installBinaryToSystem to fail with a non existing binary', a
 
   vi.spyOn(extensionApi.process, 'exec').mockRejectedValue(new Error('test error'));
 
-  await expect(() => util.installBinaryToSystem('test', 'tmpBinary')).rejects.toThrowError('test error');
+  await expect(() => util.installBinaryToSystem('test', 'tmpBinary')).rejects.toThrowError('Error making binary executable');
 });
 
 describe('grabLatestsReleasesMetadata', () => {

--- a/src/util.ts
+++ b/src/util.ts
@@ -125,7 +125,7 @@ export async function installBinaryToSystem(binaryPath: string, binaryName: stri
       await extensionApi.process.exec('chmod', ['+x', binaryPath]);
       console.log(`Made ${binaryPath} executable`);
     } catch (error) {
-      throw new Error(`Error making binary executable: ${error}`);
+      throw new Error('Error making binary executable', { cause: error });
     }
   }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "module": "esnext",
     "moduleResolution": "Node",
     "resolveJsonModule": true,
-    "lib": ["ES2017", "webworker"],
+    "lib": ["ES2022", "webworker"],
     "sourceMap": true,
     "rootDirs": ["src", "scripts"],
     "outDir": "dist",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "module": "esnext",
     "moduleResolution": "Node",
     "resolveJsonModule": true,
-    "lib": ["ES2022", "webworker"],
+    "lib": ["ES2024", "webworker"],
     "sourceMap": true,
     "rootDirs": ["src", "scripts"],
     "outDir": "dist",


### PR DESCRIPTION
This PR provides the necessary fixes for the ESlint 10 update checks to pass.
- `preserve-caught-error` has been added to the recommended config -> update tsconfig lib to at least ES2022 to support cause option in Error
- Move `file-progress` to non-compliant plugins

Needed for https://github.com/podman-desktop/extension-kind/pull/31