### PR TITLE
chore: add airgapped extension image

### DIFF
--- a/.github/workflows/build-next.yaml
+++ b/.github/workflows/build-next.yaml
@@ -67,13 +67,12 @@ jobs:
           registry: ghcr.io/${{ github.repository_owner }}
   
   extension-image:
-    name: install Kind binary
-
     name: Build and publish extension OCI image ${{ matrix.airgap == 'true' && '(Air Gap)' || ''  }}
     runs-on: ubuntu-24.04
     needs: builder-image
-    matrix:
-      airgap: ['true', 'false']
+    strategy:
+      matrix:
+        airgap: ['true', 'false']
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -104,7 +103,7 @@ jobs:
         id: extension-image
         uses: redhat-actions/buildah-build@7a95fa7ee0f02d552a32753e7414641a04307056 # v2.13
         with:
-          image: podman-desktop-kind-ext
+          image: podman-desktop-kind-ext${{ matrix.airgap == 'true' && '-airgap' || ''  }}
           tags: next ${{ github.sha }}
           archs: amd64, arm64
           containerfiles: |

--- a/.github/workflows/build-next.yaml
+++ b/.github/workflows/build-next.yaml
@@ -67,12 +67,33 @@ jobs:
           registry: ghcr.io/${{ github.repository_owner }}
   
   extension-image:
-    name: Build and publish extension OCI image
+    name: install Kind binary
+
+    name: Build and publish extension OCI image ${{ matrix.airgap == 'true' && '(Air Gap)' || ''  }}
     runs-on: ubuntu-24.04
     needs: builder-image
+    matrix:
+      airgap: ['true', 'false']
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install Kind binary for airgapped image
+        if: ${{ matrix.airgap == 'true' }}
+        run: |
+          mkdir bin
+          curl -Lo ./bin/kind-linux-amd64 https://kind.sigs.k8s.io/dl/v0.31.0/kind-linux-amd64
+          chmod +x ./bin/kind-linux-amd64
+          curl -Lo ./bin/kind-linux-arm64 https://kind.sigs.k8s.io/dl/v0.31.0/kind-linux-arm64
+          chmod +x ./bin/kind-linux-arm64
+
+          curl -Lo ./bin/kind-darwin-amd64 https://kind.sigs.k8s.io/dl/v0.31.0/kind-darwin-amd64
+          chmod +x ./bin/kind-darwin-amd64
+          curl -Lo ./bin/kind-darwin-arm64 https://kind.sigs.k8s.io/dl/v0.31.0/kind-darwin-arm64
+          chmod +x ./bin/kind-darwin-arm64
+
+          curl -Lo ./bin/kind-windows-amd64.exe https://kind.sigs.k8s.io/dl/v0.31.0/kind-windows-amd64
+          chmod +x ./bin/kind-windows-amd64.exe
 
       - name: Install qemu dependency
         run: |
@@ -90,6 +111,7 @@ jobs:
             build/Containerfile
           context: .
           oci: true
+          build-args: AIRGAP=${{ matrix.airgap }}
 
       - name: Log in to ghcr.io
         uses: redhat-actions/podman-login@4934294ad0449894bcd1e9f191899d7292469603 # v1.7

--- a/.github/workflows/build-next.yaml
+++ b/.github/workflows/build-next.yaml
@@ -105,7 +105,7 @@ jobs:
         uses: redhat-actions/buildah-build@7a95fa7ee0f02d552a32753e7414641a04307056 # v2.13
         with:
           image: podman-desktop-kind-ext-airgap-${{ matrix.os }}-${{ matrix.arch }}
-          tags: next-${{ matrix.os }}-${{ matrix.arch }} ${{ github.sha }}-${{ matrix.os }}-${{ matrix.arch }}
+          tags: next ${{ github.sha }}
           archs: ${{ matrix.arch }}
           containerfiles: |
             build/Containerfile

--- a/.github/workflows/build-next.yaml
+++ b/.github/workflows/build-next.yaml
@@ -74,6 +74,7 @@ jobs:
     runs-on: ubuntu-24.04
     needs: builder-image
     strategy:
+      fail-fast: false
       matrix:
         airgap: ['true', 'false']
 

--- a/.github/workflows/build-next.yaml
+++ b/.github/workflows/build-next.yaml
@@ -67,12 +67,18 @@ jobs:
           registry: ghcr.io/${{ github.repository_owner }}
   
   extension-image:
-    name: Build and publish extension OCI image ${{ matrix.airgap == 'true' && '(Air Gap)' || ''  }}
+    name: Build and publish extension OCI image ${{ matrix.airgap == 'true' && '(Air Gap)' || ''  }} (${{ matrix.os }}-${{ matrix.arch }})
     runs-on: ubuntu-24.04
     needs: builder-image
     strategy:
       matrix:
         airgap: ['true', 'false']
+        os: ['linux', 'darwin', 'windows']
+        arch: ['amd64', 'arm64']
+        exclude:
+          # Windows only supports amd64
+          - os: windows
+            arch: arm64
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -81,18 +87,13 @@ jobs:
         if: ${{ matrix.airgap == 'true' }}
         run: |
           mkdir bin
-          curl -Lo ./bin/kind-linux-amd64 https://kind.sigs.k8s.io/dl/v0.31.0/kind-linux-amd64
-          chmod +x ./bin/kind-linux-amd64
-          curl -Lo ./bin/kind-linux-arm64 https://kind.sigs.k8s.io/dl/v0.31.0/kind-linux-arm64
-          chmod +x ./bin/kind-linux-arm64
-
-          curl -Lo ./bin/kind-darwin-amd64 https://kind.sigs.k8s.io/dl/v0.31.0/kind-darwin-amd64
-          chmod +x ./bin/kind-darwin-amd64
-          curl -Lo ./bin/kind-darwin-arm64 https://kind.sigs.k8s.io/dl/v0.31.0/kind-darwin-arm64
-          chmod +x ./bin/kind-darwin-arm64
-
-          curl -Lo ./bin/kind-windows-amd64.exe https://kind.sigs.k8s.io/dl/v0.31.0/kind-windows-amd64
-          chmod +x ./bin/kind-windows-amd64.exe
+          DOWNLOAD_NAME="kind-${{ matrix.os }}-${{ matrix.arch }}"
+          LOCAL_NAME="${DOWNLOAD_NAME}"
+          if [ "${{ matrix.os }}" = "windows" ]; then
+            LOCAL_NAME="${LOCAL_NAME}.exe"
+          fi
+          curl -Lo ./bin/${LOCAL_NAME} https://kind.sigs.k8s.io/dl/v0.31.0/${DOWNLOAD_NAME}
+          chmod +x ./bin/${LOCAL_NAME}
 
       - name: Install qemu dependency
         run: |
@@ -103,14 +104,17 @@ jobs:
         id: extension-image
         uses: redhat-actions/buildah-build@7a95fa7ee0f02d552a32753e7414641a04307056 # v2.13
         with:
-          image: podman-desktop-kind-ext${{ matrix.airgap == 'true' && '-airgap' || ''  }}
+          image: podman-desktop-kind-ext${{ matrix.airgap == 'true' && '-airgap' || ''  }}-${{ matrix.os }}-${{ matrix.arch }}
           tags: next ${{ github.sha }}
-          archs: amd64, arm64
+          archs: ${{ matrix.arch }}
           containerfiles: |
             build/Containerfile
           context: .
           oci: true
-          build-args: AIRGAP=${{ matrix.airgap }}
+          build-args: |
+            AIRGAP=${{ matrix.airgap }}
+            TARGET_OS=${{ matrix.os }}
+            TARGET_ARCH=${{ matrix.arch }}
 
       - name: Log in to ghcr.io
         uses: redhat-actions/podman-login@4934294ad0449894bcd1e9f191899d7292469603 # v1.7

--- a/.github/workflows/build-next.yaml
+++ b/.github/workflows/build-next.yaml
@@ -69,31 +69,16 @@ jobs:
           tags: ${{ steps.builder-image.outputs.tags }}
           registry: ghcr.io/${{ github.repository_owner }}
   
-  extension-image-airgapped:
-    name: Build airgapped extension OCI image (${{ matrix.os }}-${{ matrix.arch }})
+  extension-image:
+    name: Build and publish extension OCI image ${{ matrix.airgap == 'true' && '(airgapped)' || '' }}
     runs-on: ubuntu-24.04
     needs: builder-image
     strategy:
       matrix:
-        os: ['linux', 'darwin', 'windows']
-        arch: ['amd64', 'arm64']
-        exclude:
-          - os: windows
-            arch: arm64
+        airgap: ['true', 'false']
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Install Kind binary for airgapped image
-        run: |
-          mkdir bin
-          DOWNLOAD_NAME="kind-${{ matrix.os }}-${{ matrix.arch }}"
-          LOCAL_NAME="${DOWNLOAD_NAME}"
-          if [ "${{ matrix.os }}" = "windows" ]; then
-            LOCAL_NAME="${LOCAL_NAME}.exe"
-          fi
-          curl -Lo ./bin/${LOCAL_NAME} https://kind.sigs.k8s.io/dl/${{ env.KIND_VERSION }}/${DOWNLOAD_NAME}
-          chmod +x ./bin/${LOCAL_NAME}
 
       - name: Install qemu dependency
         run: |
@@ -104,17 +89,16 @@ jobs:
         id: extension-image
         uses: redhat-actions/buildah-build@7a95fa7ee0f02d552a32753e7414641a04307056 # v2.13
         with:
-          image: podman-desktop-kind-ext-airgap-${{ matrix.os }}-${{ matrix.arch }}
+          image: podman-desktop-kind-ext${{ matrix.airgap == 'true' && '-airgap' || '' }}
           tags: next ${{ github.sha }}
-          archs: ${{ matrix.arch }}
+          platforms: ${{ matrix.airgap == 'true' && 'linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, windows/amd64' || 'linux/amd64, linux/arm64' }}
           containerfiles: |
             build/Containerfile
           context: .
           oci: true
           build-args: |
-            AIRGAP=true
-            TARGET_OS=${{ matrix.os }}
-            TARGET_ARCH=${{ matrix.arch }}
+            AIRGAP=${{ matrix.airgap }}
+            KIND_VERSION=${{ env.KIND_VERSION }}
 
       - name: Log in to ghcr.io
         uses: redhat-actions/podman-login@4934294ad0449894bcd1e9f191899d7292469603 # v1.7
@@ -131,85 +115,4 @@ jobs:
           tags: ${{ steps.extension-image.outputs.tags }}
           registry: ghcr.io/${{ github.repository_owner }}
 
-  extension-image:
-    name: Build and publish extension OCI image
-    runs-on: ubuntu-24.04
-    needs: builder-image
-
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Install qemu dependency
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y qemu-user-static
-
-      - name: build extension image
-        id: extension-image
-        uses: redhat-actions/buildah-build@7a95fa7ee0f02d552a32753e7414641a04307056 # v2.13
-        with:
-          image: podman-desktop-kind-ext
-          tags: next ${{ github.sha }}
-          archs: amd64, arm64
-          containerfiles: |
-            build/Containerfile
-          context: .
-          oci: true
-          build-args: |
-            AIRGAP=false
-
-      - name: Log in to ghcr.io
-        uses: redhat-actions/podman-login@4934294ad0449894bcd1e9f191899d7292469603 # v1.7
-        with:
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-          registry: ghcr.io
-
-      - name: publish extension to ghcr.io
-        id: push-to-ghcr
-        uses: redhat-actions/push-to-registry@5ed88d269cf581ea9ef6dd6806d01562096bee9c # v2.8
-        with:
-          image: ${{ steps.extension-image.outputs.image }}
-          tags: ${{ steps.extension-image.outputs.tags }}
-          registry: ghcr.io/${{ github.repository_owner }}
-
-  create-manifest-airgapped:
-    name: Create and publish airgapped manifest
-    runs-on: ubuntu-24.04
-    needs: extension-image-airgapped
-
-    steps:
-      - name: Log in to ghcr.io
-        uses: redhat-actions/podman-login@4934294ad0449894bcd1e9f191899d7292469603 # v1.7
-        with:
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-          registry: ghcr.io
-
-      - name: Create manifest lists
-        run: |
-          IMAGE_BASE="ghcr.io/${{ github.repository_owner }}/podman-desktop-kind-ext-airgap"
-
-          # Create manifest for next tag
-          podman manifest create ${IMAGE_BASE}:next
-          podman manifest add ${IMAGE_BASE}:next ${IMAGE_BASE}-linux-amd64:next --os linux --arch amd64
-          podman manifest add ${IMAGE_BASE}:next ${IMAGE_BASE}-linux-arm64:next --os linux --arch arm64
-          podman manifest add ${IMAGE_BASE}:next ${IMAGE_BASE}-darwin-amd64:next --os darwin --arch amd64
-          podman manifest add ${IMAGE_BASE}:next ${IMAGE_BASE}-darwin-arm64:next --os darwin --arch arm64
-          podman manifest add ${IMAGE_BASE}:next ${IMAGE_BASE}-windows-amd64:next --os windows --arch amd64
-
-          # Create manifest for SHA tag
-          podman manifest create ${IMAGE_BASE}:${{ github.sha }}
-          podman manifest add ${IMAGE_BASE}:${{ github.sha }} ${IMAGE_BASE}-linux-amd64:${{ github.sha }} --os linux --arch amd64
-          podman manifest add ${IMAGE_BASE}:${{ github.sha }} ${IMAGE_BASE}-linux-arm64:${{ github.sha }} --os linux --arch arm64
-          podman manifest add ${IMAGE_BASE}:${{ github.sha }} ${IMAGE_BASE}-darwin-amd64:${{ github.sha }} --os darwin --arch amd64
-          podman manifest add ${IMAGE_BASE}:${{ github.sha }} ${IMAGE_BASE}-darwin-arm64:${{ github.sha }} --os darwin --arch arm64
-          podman manifest add ${IMAGE_BASE}:${{ github.sha }} ${IMAGE_BASE}-windows-amd64:${{ github.sha }} --os windows --arch amd64
-
-      - name: Push manifests to ghcr.io
-        uses: redhat-actions/push-to-registry@5ed88d269cf581ea9ef6dd6806d01562096bee9c # v2.8
-        with:
-          image: podman-desktop-kind-ext-airgap
-          tags: next ${{ github.sha }}
-          registry: ghcr.io/${{ github.repository_owner }}
 

--- a/.github/workflows/build-next.yaml
+++ b/.github/workflows/build-next.yaml
@@ -69,17 +69,15 @@ jobs:
           tags: ${{ steps.builder-image.outputs.tags }}
           registry: ghcr.io/${{ github.repository_owner }}
   
-  extension-image:
-    name: Build extension OCI image ${{ matrix.airgap == 'true' && '(Air Gap)' || ''  }} (${{ matrix.os }}-${{ matrix.arch }})
+  extension-image-airgapped:
+    name: Build airgapped extension OCI image (${{ matrix.os }}-${{ matrix.arch }})
     runs-on: ubuntu-24.04
     needs: builder-image
     strategy:
       matrix:
-        airgap: ['true', 'false']
         os: ['linux', 'darwin', 'windows']
         arch: ['amd64', 'arm64']
         exclude:
-          # Windows only supports amd64
           - os: windows
             arch: arm64
 
@@ -87,7 +85,6 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install Kind binary for airgapped image
-        if: ${{ matrix.airgap == 'true' }}
         run: |
           mkdir bin
           DOWNLOAD_NAME="kind-${{ matrix.os }}-${{ matrix.arch }}"
@@ -107,7 +104,7 @@ jobs:
         id: extension-image
         uses: redhat-actions/buildah-build@7a95fa7ee0f02d552a32753e7414641a04307056 # v2.13
         with:
-          image: podman-desktop-kind-ext${{ matrix.airgap == 'true' && '-airgap' || ''  }}-${{ matrix.os }}-${{ matrix.arch }}
+          image: podman-desktop-kind-ext-airgap-${{ matrix.os }}-${{ matrix.arch }}
           tags: next-${{ matrix.os }}-${{ matrix.arch }} ${{ github.sha }}-${{ matrix.os }}-${{ matrix.arch }}
           archs: ${{ matrix.arch }}
           containerfiles: |
@@ -115,7 +112,7 @@ jobs:
           context: .
           oci: true
           build-args: |
-            AIRGAP=${{ matrix.airgap }}
+            AIRGAP=true
             TARGET_OS=${{ matrix.os }}
             TARGET_ARCH=${{ matrix.arch }}
 
@@ -134,13 +131,52 @@ jobs:
           tags: ${{ steps.extension-image.outputs.tags }}
           registry: ghcr.io/${{ github.repository_owner }}
 
-  create-manifest:
-    name: Create and publish manifest ${{ matrix.airgap == 'true' && '(Air Gap)' || ''  }}
+  extension-image:
+    name: Build and publish extension OCI image
     runs-on: ubuntu-24.04
-    needs: extension-image
-    strategy:
-      matrix:
-        airgap: ['true', 'false']
+    needs: builder-image
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install qemu dependency
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y qemu-user-static
+
+      - name: build extension image
+        id: extension-image
+        uses: redhat-actions/buildah-build@7a95fa7ee0f02d552a32753e7414641a04307056 # v2.13
+        with:
+          image: podman-desktop-kind-ext
+          tags: next ${{ github.sha }}
+          archs: amd64, arm64
+          containerfiles: |
+            build/Containerfile
+          context: .
+          oci: true
+          build-args: |
+            AIRGAP=false
+
+      - name: Log in to ghcr.io
+        uses: redhat-actions/podman-login@4934294ad0449894bcd1e9f191899d7292469603 # v1.7
+        with:
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: ghcr.io
+
+      - name: publish extension to ghcr.io
+        id: push-to-ghcr
+        uses: redhat-actions/push-to-registry@5ed88d269cf581ea9ef6dd6806d01562096bee9c # v2.8
+        with:
+          image: ${{ steps.extension-image.outputs.image }}
+          tags: ${{ steps.extension-image.outputs.tags }}
+          registry: ghcr.io/${{ github.repository_owner }}
+
+  create-manifest-airgapped:
+    name: Create and publish airgapped manifest
+    runs-on: ubuntu-24.04
+    needs: extension-image-airgapped
 
     steps:
       - name: Log in to ghcr.io
@@ -152,27 +188,28 @@ jobs:
 
       - name: Create manifest lists
         run: |
-          IMAGE_BASE="ghcr.io/${{ github.repository_owner }}/podman-desktop-kind-ext${{ matrix.airgap == 'true' && '-airgap' || ''  }}"
+          IMAGE_BASE="ghcr.io/${{ github.repository_owner }}/podman-desktop-kind-ext-airgap"
 
           # Create manifest for next tag
           podman manifest create ${IMAGE_BASE}:next
-          podman manifest add ${IMAGE_BASE}:next ${IMAGE_BASE}-linux-amd64:next-linux-amd64 --os linux --arch amd64
-          podman manifest add ${IMAGE_BASE}:next ${IMAGE_BASE}-linux-arm64:next-linux-arm64 --os linux --arch arm64
-          podman manifest add ${IMAGE_BASE}:next ${IMAGE_BASE}-darwin-amd64:next-darwin-amd64 --os darwin --arch amd64
-          podman manifest add ${IMAGE_BASE}:next ${IMAGE_BASE}-darwin-arm64:next-darwin-arm64 --os darwin --arch arm64
-          podman manifest add ${IMAGE_BASE}:next ${IMAGE_BASE}-windows-amd64:next-windows-amd64 --os windows --arch amd64
+          podman manifest add ${IMAGE_BASE}:next ${IMAGE_BASE}-linux-amd64:next --os linux --arch amd64
+          podman manifest add ${IMAGE_BASE}:next ${IMAGE_BASE}-linux-arm64:next --os linux --arch arm64
+          podman manifest add ${IMAGE_BASE}:next ${IMAGE_BASE}-darwin-amd64:next --os darwin --arch amd64
+          podman manifest add ${IMAGE_BASE}:next ${IMAGE_BASE}-darwin-arm64:next --os darwin --arch arm64
+          podman manifest add ${IMAGE_BASE}:next ${IMAGE_BASE}-windows-amd64:next --os windows --arch amd64
 
           # Create manifest for SHA tag
           podman manifest create ${IMAGE_BASE}:${{ github.sha }}
-          podman manifest add ${IMAGE_BASE}:${{ github.sha }} ${IMAGE_BASE}-linux-amd64:${{ github.sha }}-linux-amd64 --os linux --arch amd64
-          podman manifest add ${IMAGE_BASE}:${{ github.sha }} ${IMAGE_BASE}-linux-arm64:${{ github.sha }}-linux-arm64 --os linux --arch arm64
-          podman manifest add ${IMAGE_BASE}:${{ github.sha }} ${IMAGE_BASE}-darwin-amd64:${{ github.sha }}-darwin-amd64 --os darwin --arch amd64
-          podman manifest add ${IMAGE_BASE}:${{ github.sha }} ${IMAGE_BASE}-darwin-arm64:${{ github.sha }}-darwin-arm64 --os darwin --arch arm64
-          podman manifest add ${IMAGE_BASE}:${{ github.sha }} ${IMAGE_BASE}-windows-amd64:${{ github.sha }}-windows-amd64 --os windows --arch amd64
+          podman manifest add ${IMAGE_BASE}:${{ github.sha }} ${IMAGE_BASE}-linux-amd64:${{ github.sha }} --os linux --arch amd64
+          podman manifest add ${IMAGE_BASE}:${{ github.sha }} ${IMAGE_BASE}-linux-arm64:${{ github.sha }} --os linux --arch arm64
+          podman manifest add ${IMAGE_BASE}:${{ github.sha }} ${IMAGE_BASE}-darwin-amd64:${{ github.sha }} --os darwin --arch amd64
+          podman manifest add ${IMAGE_BASE}:${{ github.sha }} ${IMAGE_BASE}-darwin-arm64:${{ github.sha }} --os darwin --arch arm64
+          podman manifest add ${IMAGE_BASE}:${{ github.sha }} ${IMAGE_BASE}-windows-amd64:${{ github.sha }} --os windows --arch amd64
 
       - name: Push manifests to ghcr.io
         uses: redhat-actions/push-to-registry@5ed88d269cf581ea9ef6dd6806d01562096bee9c # v2.8
         with:
-          image: podman-desktop-kind-ext${{ matrix.airgap == 'true' && '-airgap' || ''  }}
+          image: podman-desktop-kind-ext-airgap
           tags: next ${{ github.sha }}
           registry: ghcr.io/${{ github.repository_owner }}
+

--- a/.github/workflows/build-next.yaml
+++ b/.github/workflows/build-next.yaml
@@ -26,6 +26,9 @@ on:
     branches:
       - 'main'
 
+env:
+  KIND_VERSION: v0.31.0
+
 jobs:
   builder-image:
     name: Build and publish builder OCI image
@@ -67,7 +70,7 @@ jobs:
           registry: ghcr.io/${{ github.repository_owner }}
   
   extension-image:
-    name: Build and publish extension OCI image ${{ matrix.airgap == 'true' && '(Air Gap)' || ''  }} (${{ matrix.os }}-${{ matrix.arch }})
+    name: Build extension OCI image ${{ matrix.airgap == 'true' && '(Air Gap)' || ''  }} (${{ matrix.os }}-${{ matrix.arch }})
     runs-on: ubuntu-24.04
     needs: builder-image
     strategy:
@@ -92,7 +95,7 @@ jobs:
           if [ "${{ matrix.os }}" = "windows" ]; then
             LOCAL_NAME="${LOCAL_NAME}.exe"
           fi
-          curl -Lo ./bin/${LOCAL_NAME} https://kind.sigs.k8s.io/dl/v0.31.0/${DOWNLOAD_NAME}
+          curl -Lo ./bin/${LOCAL_NAME} https://kind.sigs.k8s.io/dl/${{ env.KIND_VERSION }}/${DOWNLOAD_NAME}
           chmod +x ./bin/${LOCAL_NAME}
 
       - name: Install qemu dependency
@@ -105,7 +108,7 @@ jobs:
         uses: redhat-actions/buildah-build@7a95fa7ee0f02d552a32753e7414641a04307056 # v2.13
         with:
           image: podman-desktop-kind-ext${{ matrix.airgap == 'true' && '-airgap' || ''  }}-${{ matrix.os }}-${{ matrix.arch }}
-          tags: next ${{ github.sha }}
+          tags: next-${{ matrix.os }}-${{ matrix.arch }} ${{ github.sha }}-${{ matrix.os }}-${{ matrix.arch }}
           archs: ${{ matrix.arch }}
           containerfiles: |
             build/Containerfile
@@ -129,4 +132,47 @@ jobs:
         with:
           image: ${{ steps.extension-image.outputs.image }}
           tags: ${{ steps.extension-image.outputs.tags }}
+          registry: ghcr.io/${{ github.repository_owner }}
+
+  create-manifest:
+    name: Create and publish manifest ${{ matrix.airgap == 'true' && '(Air Gap)' || ''  }}
+    runs-on: ubuntu-24.04
+    needs: extension-image
+    strategy:
+      matrix:
+        airgap: ['true', 'false']
+
+    steps:
+      - name: Log in to ghcr.io
+        uses: redhat-actions/podman-login@4934294ad0449894bcd1e9f191899d7292469603 # v1.7
+        with:
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: ghcr.io
+
+      - name: Create manifest lists
+        run: |
+          IMAGE_BASE="ghcr.io/${{ github.repository_owner }}/podman-desktop-kind-ext${{ matrix.airgap == 'true' && '-airgap' || ''  }}"
+
+          # Create manifest for next tag
+          podman manifest create ${IMAGE_BASE}:next
+          podman manifest add ${IMAGE_BASE}:next ${IMAGE_BASE}-linux-amd64:next-linux-amd64 --os linux --arch amd64
+          podman manifest add ${IMAGE_BASE}:next ${IMAGE_BASE}-linux-arm64:next-linux-arm64 --os linux --arch arm64
+          podman manifest add ${IMAGE_BASE}:next ${IMAGE_BASE}-darwin-amd64:next-darwin-amd64 --os darwin --arch amd64
+          podman manifest add ${IMAGE_BASE}:next ${IMAGE_BASE}-darwin-arm64:next-darwin-arm64 --os darwin --arch arm64
+          podman manifest add ${IMAGE_BASE}:next ${IMAGE_BASE}-windows-amd64:next-windows-amd64 --os windows --arch amd64
+
+          # Create manifest for SHA tag
+          podman manifest create ${IMAGE_BASE}:${{ github.sha }}
+          podman manifest add ${IMAGE_BASE}:${{ github.sha }} ${IMAGE_BASE}-linux-amd64:${{ github.sha }}-linux-amd64 --os linux --arch amd64
+          podman manifest add ${IMAGE_BASE}:${{ github.sha }} ${IMAGE_BASE}-linux-arm64:${{ github.sha }}-linux-arm64 --os linux --arch arm64
+          podman manifest add ${IMAGE_BASE}:${{ github.sha }} ${IMAGE_BASE}-darwin-amd64:${{ github.sha }}-darwin-amd64 --os darwin --arch amd64
+          podman manifest add ${IMAGE_BASE}:${{ github.sha }} ${IMAGE_BASE}-darwin-arm64:${{ github.sha }}-darwin-arm64 --os darwin --arch arm64
+          podman manifest add ${IMAGE_BASE}:${{ github.sha }} ${IMAGE_BASE}-windows-amd64:${{ github.sha }}-windows-amd64 --os windows --arch amd64
+
+      - name: Push manifests to ghcr.io
+        uses: redhat-actions/push-to-registry@5ed88d269cf581ea9ef6dd6806d01562096bee9c # v2.8
+        with:
+          image: podman-desktop-kind-ext${{ matrix.airgap == 'true' && '-airgap' || ''  }}
+          tags: next ${{ github.sha }}
           registry: ghcr.io/${{ github.repository_owner }}

--- a/build/Containerfile
+++ b/build/Containerfile
@@ -17,26 +17,30 @@
 
 FROM ghcr.io/podman-desktop/podman-desktop-kind-ext-builder:next AS builder
 
+ARG AIRGAP="false"
+
 COPY . .
 
 RUN pnpm --frozen-lockfile install && \
     pnpm build
 
+RUN mkdir /opt/app-root/extension && \
+    cp -r dist /opt/app-root/extension/
+
+RUN if [ $AIRGAP = "true" ]; then \
+    cp -r bin /opt/app-root/extension/ ; \
+fi
+
+COPY package.json /opt/app-root/extension/
+COPY LICENSE /opt/app-root/extension/
+COPY README.md /opt/app-root/extension/
+COPY icon.png /opt/app-root/extension/
 
 FROM scratch
-ARG AIRPAG="false"
 
 LABEL org.opencontainers.image.title="Kind extension" \
       org.opencontainers.image.description="Kind extension" \
       org.opencontainers.image.vendor="podman-desktop" \
       io.podman-desktop.api.version=">= 1.24.0"
 
-RUN if [ $AIRPAG = "true" ]; then \
-    cp bin /extension/ ; \
-fi
-
-COPY package.json /extension/
-COPY LICENSE /extension/
-COPY icon.png /extension/
-COPY README.md /extension/
-COPY --from=builder /opt/app-root/src/dist /extension/dist
+COPY --from=builder /opt/app-root/extension /extension

--- a/build/Containerfile
+++ b/build/Containerfile
@@ -24,11 +24,16 @@ RUN pnpm --frozen-lockfile install && \
 
 
 FROM scratch
+ARG AIRPAG="false"
 
 LABEL org.opencontainers.image.title="Kind extension" \
       org.opencontainers.image.description="Kind extension" \
       org.opencontainers.image.vendor="podman-desktop" \
       io.podman-desktop.api.version=">= 1.24.0"
+
+RUN if [ $AIRPAG = "true" ]; then \
+    cp bin /extension/ ; \
+fi
 
 COPY package.json /extension/
 COPY LICENSE /extension/

--- a/build/Containerfile
+++ b/build/Containerfile
@@ -33,7 +33,7 @@ RUN mkdir /opt/app-root/extension && \
 RUN if [ "$AIRGAP" = "true" ]; then \
     mkdir /opt/app-root/extension/bin && \
     DOWNLOAD_NAME="kind-${TARGETOS}-${TARGETARCH}" && \
-    LOCAL_NAME="${DOWNLOAD_NAME}" && \
+    LOCAL_NAME="kind" && \
     if [ "${TARGETOS}" = "windows" ]; then \
         LOCAL_NAME="${LOCAL_NAME}.exe" ; \
     fi && \

--- a/build/Containerfile
+++ b/build/Containerfile
@@ -18,6 +18,8 @@
 FROM ghcr.io/podman-desktop/podman-desktop-kind-ext-builder:next AS builder
 
 ARG AIRGAP="false"
+ARG TARGET_OS
+ARG TARGET_ARCH
 
 COPY . .
 
@@ -27,8 +29,13 @@ RUN pnpm --frozen-lockfile install && \
 RUN mkdir /opt/app-root/extension && \
     cp -r dist /opt/app-root/extension/
 
-RUN if [ $AIRGAP = "true" ]; then \
-    cp -r bin /opt/app-root/extension/ ; \
+RUN if [ "$AIRGAP" = "true" ]; then \
+    mkdir /opt/app-root/extension/bin && \
+    BINARY_NAME="kind-${TARGET_OS}-${TARGET_ARCH}" && \
+    if [ "${TARGET_OS}" = "windows" ]; then \
+        BINARY_NAME="${BINARY_NAME}.exe" ; \
+    fi && \
+    cp bin/${BINARY_NAME} /opt/app-root/extension/bin/ ; \
 fi
 
 COPY package.json /opt/app-root/extension/

--- a/build/Containerfile
+++ b/build/Containerfile
@@ -18,8 +18,9 @@
 FROM ghcr.io/podman-desktop/podman-desktop-kind-ext-builder:next AS builder
 
 ARG AIRGAP="false"
-ARG TARGET_OS
-ARG TARGET_ARCH
+ARG TARGETOS
+ARG TARGETARCH
+ARG KIND_VERSION
 
 COPY . .
 
@@ -31,11 +32,13 @@ RUN mkdir /opt/app-root/extension && \
 
 RUN if [ "$AIRGAP" = "true" ]; then \
     mkdir /opt/app-root/extension/bin && \
-    BINARY_NAME="kind-${TARGET_OS}-${TARGET_ARCH}" && \
-    if [ "${TARGET_OS}" = "windows" ]; then \
-        BINARY_NAME="${BINARY_NAME}.exe" ; \
+    DOWNLOAD_NAME="kind-${TARGETOS}-${TARGETARCH}" && \
+    LOCAL_NAME="${DOWNLOAD_NAME}" && \
+    if [ "${TARGETOS}" = "windows" ]; then \
+        LOCAL_NAME="${LOCAL_NAME}.exe" ; \
     fi && \
-    cp bin/${BINARY_NAME} /opt/app-root/extension/bin/ ; \
+    curl -Lo /opt/app-root/extension/bin/${LOCAL_NAME} https://kind.sigs.k8s.io/dl/${KIND_VERSION}/${DOWNLOAD_NAME} && \
+    chmod +x /opt/app-root/extension/bin/${LOCAL_NAME} ; \
 fi
 
 COPY package.json /opt/app-root/extension/

--- a/build/Containerfile
+++ b/build/Containerfile
@@ -15,7 +15,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM ghcr.io/podman-desktop/podman-desktop-kind-ext-builder:next AS builder
+FROM --platform=$BUILDPLATFORM ghcr.io/podman-desktop/podman-desktop-kind-ext-builder:next AS builder
 
 ARG AIRGAP="false"
 ARG TARGETOS

--- a/build/Containerfile
+++ b/build/Containerfile
@@ -37,7 +37,7 @@ RUN if [ "$AIRGAP" = "true" ]; then \
     if [ "${TARGETOS}" = "windows" ]; then \
         LOCAL_NAME="${LOCAL_NAME}.exe" ; \
     fi && \
-    curl -Lo /opt/app-root/extension/bin/${LOCAL_NAME} https://kind.sigs.k8s.io/dl/${KIND_VERSION}/${DOWNLOAD_NAME} && \
+    curl -fLo /opt/app-root/extension/bin/${LOCAL_NAME} https://kind.sigs.k8s.io/dl/${KIND_VERSION}/${DOWNLOAD_NAME} && \
     chmod +x /opt/app-root/extension/bin/${LOCAL_NAME} ; \
 fi
 


### PR DESCRIPTION
This PR adds an airgapped extension image that include the Kind binaries for linux arm and amd, darwin arm and amd, and windows
Currently, this update will only include the `build-next` workflow

ghcr.io/soniasandler/podman-desktop-kind-ext-airgap:next
ghcr.io/soniasandler/podman-desktop-kind-ext:next

Closes https://github.com/podman-desktop/extension-kind/issues/2