### PR TITLE
fix: resolve CVE-2026-32141 in flatted

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,7 +123,8 @@
   "pnpm": {
     "overrides": {
       "minimatch@<3.1.3": "3.1.3",
-      "minimatch@>=4.0.0-0 <9.0.6": "9.0.6"
+      "minimatch@>=4.0.0-0 <9.0.6": "9.0.6",
+      "flatted@<3.4.2": "3.4.2"
     }
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,7 @@ settings:
 overrides:
   minimatch@<3.1.3: 3.1.3
   minimatch@>=4.0.0-0 <9.0.6: 9.0.6
+  flatted@<3.4.2: 3.4.2
 
 importers:
 
@@ -1617,8 +1618,8 @@ packages:
     resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
     engines: {node: '>=16'}
 
-  flatted@3.3.3:
-    resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
+  flatted@3.4.2:
+    resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
   for-each@0.3.5:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
@@ -4280,10 +4281,10 @@ snapshots:
 
   flat-cache@4.0.1:
     dependencies:
-      flatted: 3.3.3
+      flatted: 3.4.2
       keyv: 4.5.4
 
-  flatted@3.3.3: {}
+  flatted@3.4.2: {}
 
   for-each@0.3.5:
     dependencies:


### PR DESCRIPTION
### What does this PR do?

Fix high severity vulnerability CVE-2026-32141 in `flatted`.

**Advisory**: flatted vulnerable to unbounded recursion DoS in parse() revive phase
**Vulnerable versions**: <3.4.0
**Patched versions**: >=3.4.0
**Advisory URL**: https://github.com/advisories/GHSA-25h7-pfq9-p65f

### Screenshot / video of UI

N/A - dependency update only.

### What issues does this PR fix or reference?

Fixes CVE-2026-32141: _flatted vulnerable to unbounded recursion DoS in parse() revive phase_

### How to test this PR?

Run `pnpm audit` and verify CVE-2026-32141 is no longer reported