### PR TITLE
fix: resolve CVE-2026-42338 in ip-address

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,7 +127,8 @@
       "flatted@<3.4.2": "3.4.2",
       "picomatch@>=4.0.0 <4.0.4": "^4.0.4",
       "ajv@<6.14.0": "^6.14.0",
-      "brace-expansion@<1.1.13": "^1.1.13"
+      "brace-expansion@<1.1.13": "^1.1.13",
+      "ip-address@<=10.1.0": ">=10.1.1"
     }
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,7 @@ overrides:
   picomatch@>=4.0.0 <4.0.4: ^4.0.4
   ajv@<6.14.0: ^6.14.0
   brace-expansion@<1.1.13: ^1.1.13
+  ip-address@<=10.1.0: '>=10.1.1'
 
 importers:
 
@@ -1765,8 +1766,8 @@ packages:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
 
-  ip-address@10.1.0:
-    resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
+  ip-address@10.2.0:
+    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
     engines: {node: '>= 12'}
 
   is-array-buffer@3.0.5:
@@ -4435,7 +4436,7 @@ snapshots:
       hasown: 2.0.2
       side-channel: 1.1.0
 
-  ip-address@10.1.0: {}
+  ip-address@10.2.0: {}
 
   is-array-buffer@3.0.5:
     dependencies:
@@ -5055,7 +5056,7 @@ snapshots:
 
   socks@2.8.7:
     dependencies:
-      ip-address: 10.1.0
+      ip-address: 10.2.0
       smart-buffer: 4.2.0
 
   source-map-js@1.2.1: {}


### PR DESCRIPTION
### What does this PR do?

Fix moderate severity vulnerability CVE-2026-42338 in `ip-address`.

**Advisory**: ip-address has XSS in Address6 HTML-emitting methods
**Vulnerable versions**: <=10.1.0
**Patched versions**: >=10.1.1
**Advisory URL**: https://github.com/advisories/GHSA-v2v4-37r5-5v8g

### Screenshot / video of UI

N/A - dependency update only.

### What issues does this PR fix or reference?

Fixes CVE-2026-42338: _ip-address has XSS in Address6 HTML-emitting methods_

### How to test this PR?

Run `pnpm audit` and verify CVE-2026-42338 is no longer reported