### PR TITLE
chore(build): migrate from pnpm v10 to v11

### DIFF
--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -36,7 +36,6 @@ jobs:
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         name: Install pnpm
         with:
-          version: 10
           run_install: false
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -62,7 +61,6 @@ jobs:
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         name: Install pnpm
         with:
-          version: 10
           run_install: false
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -89,7 +87,6 @@ jobs:
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         name: Install pnpm
         with:
-          version: 10
           run_install: false
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/build/Containerfile
+++ b/build/Containerfile
@@ -24,7 +24,7 @@ ARG KIND_VERSION
 
 COPY . .
 
-RUN pnpm --frozen-lockfile install && \
+RUN CI=true pnpm --frozen-lockfile install && \
     pnpm build
 
 RUN mkdir /opt/app-root/extension && \

--- a/build/Containerfile.builder
+++ b/build/Containerfile.builder
@@ -19,6 +19,11 @@ FROM registry.access.redhat.com/ubi9/nodejs-24:9.7-1766414990
 
 COPY package.json .
 COPY pnpm-lock.yaml .
+COPY pnpm-workspace.yaml .
 
-RUN npm install --global pnpm@10 && \
-    pnpm --frozen-lockfile install
+USER root
+RUN npm i -g corepack && corepack enable
+USER default
+
+RUN corepack install && \
+    CI=true pnpm --frozen-lockfile install

--- a/package.json
+++ b/package.json
@@ -120,22 +120,6 @@
     "mustache": "^4.2.0",
     "yaml": "^2.9.0"
   },
-  "pnpm": {
-    "overrides": {
-      "minimatch@<3.1.4": "^3.1.4",
-      "minimatch@>=4.0.0-0 <9.0.7": "^9.0.7",
-      "flatted@<3.4.2": "3.4.2",
-      "picomatch@>=4.0.0 <4.0.4": "^4.0.4",
-      "ajv@<6.14.0": "^6.14.0",
-      "brace-expansion@<1.1.16": "^1.1.16",
-      "ip-address@<=10.1.0": ">=10.1.1",
-      "tmp@<0.2.7": ">=0.2.7",
-      "ws@>=8.0.0 <8.20.1": ">=8.20.1",
-      "esbuild@>=0.17.0 <0.28.1": ">=0.28.1",
-      "form-data@>=4.0.0 <4.0.6": ">=4.0.6",
-      "js-yaml@>=4.0.0 <4.3.0": "4.3.0"
-    }
-  },
   "devDependencies": {
     "@biomejs/biome": "^2.5.5",
     "@eslint/compat": "^2.1.0",
@@ -165,5 +149,6 @@
     "typescript-eslint": "^8.65.0",
     "vite": "^8.1.5",
     "vitest": "^4.1.8"
-  }
+  },
+  "packageManager": "pnpm@11.16.0+sha512.b767e9a98fc87aec0f42daefcd0e84941c2cdb45d73c4e1e68860fb2bdfdbe032ab592105479e5e05c237f740c8a5ffdbbb52385797ddc2296745a1bbb883e8d"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,16 @@
+allowBuilds:
+  esbuild: true
+  unrs-resolver: true
+overrides:
+  minimatch@<3.1.4: ^3.1.4
+  minimatch@>=4.0.0-0 <9.0.7: ^9.0.7
+  flatted@<3.4.2: 3.4.2
+  picomatch@>=4.0.0 <4.0.4: ^4.0.4
+  ajv@<6.14.0: ^6.14.0
+  brace-expansion@<1.1.16: ^1.1.16
+  ip-address@<=10.1.0: '>=10.1.1'
+  tmp@<0.2.7: '>=0.2.7'
+  ws@>=8.0.0 <8.20.1: '>=8.20.1'
+  esbuild@>=0.17.0 <0.28.1: '>=0.28.1'
+  form-data@>=4.0.0 <4.0.6: '>=4.0.6'
+  js-yaml@>=4.0.0 <4.3.0: 4.3.0


### PR DESCRIPTION
Moves pnpm.overrides from package.json to pnpm-workspace.yaml and introduces pnpm-workspace.yaml with allowBuilds for esbuild and unrs-resolver. Pins the version in packageManager with a sha512 hash for Corepack verification.

Builder Containerfile is updated to install pnpm via Corepack (required on UBI images that don't ship corepack) and now copies pnpm-workspace.yaml so frozen installs don't fail with a lockfile config mismatch. CI=true is added to pnpm install calls in both Containerfiles.

GitHub Actions workflows drop the hardcoded version: 10 from pnpm/action-setup; the action now reads the version from packageManager.